### PR TITLE
Open API をはずす

### DIFF
--- a/km-server-impl/src/main/java/org/visualpaper/work/km/server/impl/resources/HealthCheckResource.java
+++ b/km-server-impl/src/main/java/org/visualpaper/work/km/server/impl/resources/HealthCheckResource.java
@@ -2,16 +2,21 @@ package org.visualpaper.work.km.server.impl.resources;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.visualpaper.work.km.server.impl.openapi.api.HealthCheckApi;
 
 @RestController
-public class HealthCheckResource implements HealthCheckApi {
+public class HealthCheckResource {
 
   /**
    * HealthCheck API.
    */
-  @Override
+  @RequestMapping(
+      method = RequestMethod.GET,
+      value = "/healthCheck",
+      produces = { "application/json" }
+  )
   public ResponseEntity<Void> getHealthCheck() throws Exception {
     return new ResponseEntity<>(HttpStatus.OK);
   }


### PR DESCRIPTION
Open API の使い勝手は良いが、学習コストが高いのと、細かいバリデーションを行いたいユースケースにちょっと合わないので消す